### PR TITLE
Potential fix for code scanning alert no. 1: Double escaping or unescaping

### DIFF
--- a/electron-app/js/ui/documentViewer.js
+++ b/electron-app/js/ui/documentViewer.js
@@ -382,9 +382,9 @@ class DocumentViewer {
             return text
                 .replace(/&lt;/g, '<')
                 .replace(/&gt;/g, '>')
-                .replace(/&amp;/g, '&')
                 .replace(/&quot;/g, '"')
-                .replace(/&nbsp;/g, ' ');
+                .replace(/&nbsp;/g, ' ')
+                .replace(/&amp;/g, '&');
         };
         
         // Helper to process inline formatting recursively


### PR DESCRIPTION
Potential fix for [https://github.com/TiLT42/RogueTraderGeneratorTools/security/code-scanning/1](https://github.com/TiLT42/RogueTraderGeneratorTools/security/code-scanning/1)

General fix: when manually decoding HTML entities, ensure that the escape character `&` is decoded *last* to avoid converting encoded ampersands into literal `&` that then participate in other entity sequences. That means reordering the `replace` calls so `&amp;` is handled after `&lt;`, `&gt;`, `&quot;`, and `&nbsp;`, or—more robustly—using a standard library routine for HTML entity decoding.

Best fix here: keep the existing lightweight approach but change the order of replacements inside `decodeHTMLEntities` so that `&amp;` is decoded last. This keeps behavior compatible for all the entities it already handles, but removes the possibility of double-unescaping and matches the recommended pattern from the background section. Specifically, in `electron-app/js/ui/documentViewer.js`, within `htmlToRTF`’s inner function `decodeHTMLEntities`, move the `.replace(/&amp;/g, '&')` call to the end of the chain, after `&lt;`, `&gt;`, `&quot;`, and `&nbsp;`.

This change requires no new functions or imports; we only adjust the order of existing `replace` calls on lines 383–387 in the snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
